### PR TITLE
Fix title bar text not scaled to dpi change

### DIFF
--- a/main.c
+++ b/main.c
@@ -369,7 +369,7 @@ win32_custom_title_bar_example_window_callback(
       // Draw window title
       LOGFONT logical_font;
       HFONT old_font = NULL;
-      if (SUCCEEDED(GetThemeSysFont(theme, TMT_CAPTIONFONT, &logical_font))) {
+      if (SUCCEEDED(SystemParametersInfoForDpi(SPI_GETICONTITLELOGFONT, sizeof(logical_font), &logical_font, false, dpi))) {
         HFONT theme_font = CreateFontIndirect(&logical_font);
         old_font = (HFONT)SelectObject(hdc, theme_font);
       }


### PR DESCRIPTION
Thanks for this awesome demo. I made a little fix for the title bar text so that it scales do dpi changes for multiple monitors.
Before:
 
![image](https://user-images.githubusercontent.com/42881734/173494184-be95f379-4f4b-4624-91f6-ef845070b6b3.png)
![image](https://user-images.githubusercontent.com/42881734/173494193-15301183-4f11-4f41-b3dd-b8fe0047196f.png)


After:
![image](https://user-images.githubusercontent.com/42881734/173494129-89a26aae-0159-4312-928a-6acea87963af.png)
![image](https://user-images.githubusercontent.com/42881734/173494141-a7ab23e4-d499-4578-9eea-ff8bb009e19b.png)
